### PR TITLE
Update sharp version to match ember-responsive-image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "10"
 
 sudo: false
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
     "ember-cli-lazysizes": "^0.1.1",
-    "sharp": "^0.21.1"
+    "sharp": "^0.25.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "mocha": "^5.0.0"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
v0.1.0 fails to install with an error building sharp
```
    error /.../node_modules/sharp: Command failed.
...

  TOUCH Release/obj.target/libvips-cpp.stamp
  CXX(target) Release/obj.target/sharp/src/common.o
In file included from ../src/common.cc:27:
../src/common.h:80:20: error: no member named 'Handle' in namespace 'v8'
  bool HasAttr(v8::Handle<v8::Object> obj, std::string attr);
               ~~~~^
```

I'm not 100% sure on the source of this issue, it might be a macOS or Node 12 thing, but updating sharp to the same version as used by `ember-responsive-image` fixes it.

Notably this version of sharp requires Node 10. I have updated `package.json` and `.travis.yml` to reflect this.
